### PR TITLE
A non-numeric value encountered (resolved)

### DIFF
--- a/classes/debug.class.php
+++ b/classes/debug.class.php
@@ -139,7 +139,7 @@ class DEBUG {
         $Return = array();
         foreach ($Array as $Key => $Val) {
             $Return[$Key] = '';
-            if (!is_int($Key) || $Key != $LastKey + 1) {
+            if (!is_int($Key) || $Key != intval($LastKey) + 1) {
                 $Return[$Key] .= "'$Key' => ";
             }
             if ($Val === true) {


### PR DESCRIPTION
不知道 PHP 的哪个版本开始，当使用一些(+ – * / ** % << >> | & ^) 的运算符号后，如何类型不确定，那么 php 就会出现 Warning: A non-numeric value encountered 的错误提示，翻译成中文的大概意思就是“遇到一个非数值”，就表示数字运算中出现了一个不是数字的值，很多时候其实程序本身是可以正常被继续运行和使用，只是说不严谨或者结果不准确等情况就出现了，所以还是非常有必要解决和重视的。