### PR TITLE
fix(torrent.class.php): correct can_use_token check

### DIFF
--- a/classes/torrents.class.php
+++ b/classes/torrents.class.php
@@ -1389,7 +1389,7 @@ WHERE ud.TorrentID=? AND ui.NotifyOnDeleteDownloaded='1' AND ud.UserID NOT IN ({
             return false;
         }
 
-        return (G::$LoggedUser['FLTokens'] >= 0
+        return (G::$LoggedUser['FLTokens'] >= 1
             && !$Torrent['PersonalFL']
             && (in_array($Torrent['FreeTorrent'], ['11', '12', '13']) || empty($Torrent['FreeTorrent']))
             && G::$LoggedUser['CanLeech'] == '1');


### PR DESCRIPTION
This should fix the "canUseToken" property in the api to correctly check if the Logged in User has 1 or more Freeleech tokens to use