### PR TITLE
Fix: Error when running docker-compose -p gazelle up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR /var/www
 


### PR DESCRIPTION
Resolve bug [issues #56](https://github.com/Mosasauroidea/GazellePW/issues/56)
This bug occurs because Ubuntu 18.04 has reached end of standard support