### PR TITLE
shell line endlings support on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure shell script uses LF.
+Dockerfile  eol=lf
+*.sh        eol=lf
+*.bat       eol=crlf


### PR DESCRIPTION
Fix the error when building images on Windows caused by the newline character in the Dockerfile.

修复在windows环境下因为Dockerfile文件的换行符不同，构建镜像报错的问题