### PR TITLE
Fix BBCode editor toolbar in report page

### DIFF
--- a/sections/reportsv2/ajax_report.php
+++ b/sections/reportsv2/ajax_report.php
@@ -106,12 +106,3 @@ if (array_key_exists('proofimages', $ReportType['report_fields'])) {
 <?
 }
 ?>
-<tr class="Form-row">
-    <td class="Form-label">
-        <?= t('server.reportsv2.comments') ?> <strong class="u-colorWarning">(<?= t('server.reportsv2.required') ?>)</strong>:
-    </td>
-    <td class="Form-items">
-        <? new TEXTAREA_PREVIEW('extra', 'extra', display_str($_POST['extra'])); ?>
-    </td>
-
-</tr>

--- a/sections/reportsv2/report.php
+++ b/sections/reportsv2/report.php
@@ -79,6 +79,16 @@ View::show_header(t('server.reportsv2.report'), 'reportsv2,browse,torrent,bbcode
         </table>
         <table>
             <tr class="Form-row">
+                <td class="Form-label">
+                    <?= t('server.reportsv2.comments') ?> <strong class="u-colorWarning">(<?= t('server.reportsv2.required') ?>)</strong>:
+                </td>
+                <td class="Form-items">
+                    <? new TEXTAREA_PREVIEW('extra', 'extra', display_str($_POST['extra'])); ?>
+                </td>
+            </tr>
+        </table>
+        <table>
+            <tr class="Form-row">
                 <td colspan="2">
                     <input class="Button" type="submit" value="<?= t('server.common.submit') ?>" />
                 </td>


### PR DESCRIPTION
Fix the BBCode editor toolbar not working in the torrent report page.